### PR TITLE
Update Audi-S6 generations: Add facelifts as separate entries and correct production dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Audi S6
 
+This repository contains signal set configurations for the Audi S6, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi S6.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_S6"
+
 generations:
   - name: "First Generation (C4)"
     start_year: 1994
@@ -10,16 +13,26 @@ generations:
     description: "The C5 S6 was exclusively powered by a 4.2L V8 engine producing 340 HP, paired with a five-speed Tiptronic automatic transmission and quattro all-wheel drive. Available in both sedan and Avant body styles, it featured more distinctive styling elements compared to its predecessor, including polished aluminum exterior mirrors and unique wheels."
 
   - name: "Third Generation (C6)"
-    start_year: 2006
-    end_year: 2011
+    start_year: 2005
+    end_year: 2008
     description: "The C6 S6 featured a significant powertrain upgrade with a Lamborghini-derived 5.2L V10 engine producing 435 HP, paired with a six-speed Tiptronic automatic transmission. Available in sedan and Avant body styles, it featured more aggressive styling with wider fenders, distinctive front and rear bumpers, and quad exhaust tips. The V10 engine provided a unique character and exhaust note that distinguished it from competitors."
+
+  - name: "Third Generation (C6 Facelift)"
+    start_year: 2009
+    end_year: 2011
+    description: "The facelifted C6 S6 was released in late 2008 for the 2009 model year. The facelift maintained the iconic 5.2L Lamborghini-derived V10 engine but introduced updated styling elements, an upgraded MMI electronics controller (third-generation in 2010), and improved infotainment systems. The exterior retained the signature LED daytime running lights while the interior received technology enhancements and real-time traffic information capabilities."
 
   - name: "Fourth Generation (C7)"
     start_year: 2012
+    end_year: 2014
+    description: "The C7 S6 launched as a 2013 model, a year after the C7 A6. It returned to V8 power with a twin-turbocharged 4.0L engine producing 420 HP, paired with a seven-speed S tronic dual-clutch transmission. Built on the C7 platform, it featured cylinder deactivation technology for improved fuel efficiency. The exterior continued the tradition of subtle performance enhancements while the interior offered a blend of luxury and sportiness with distinctive S elements."
+
+  - name: "Fourth Generation (C7 Facelift)"
+    start_year: 2015
     end_year: 2018
-    description: "The C7 S6 returned to V8 power with a twin-turbocharged 4.0L engine producing 420 HP (later increased to 450 HP), paired with a seven-speed S tronic dual-clutch transmission. Built on the MLB platform, it featured cylinder deactivation technology for improved fuel efficiency. The exterior continued the tradition of subtle performance enhancements while the interior offered a blend of luxury and sportiness with distinctive S elements."
+    description: "Audi unveiled the 2015 S6 facelift in November 2014. Changes included styling tweaks to the exterior, an upgraded Multi Media Interface with faster Nvidia Tegra 3 processor and improved graphics with handwriting recognition, Audi connect telematics with 4G mobile internet and map updates, adaptive glare-free Matrix LED headlights, and an improved Night Vision Assistant. The 4.0L twin-turbo V8 was upgraded from 420 HP to 450 HP, and both TFSI petrol and all three TDI diesel engines now met the Euro 6 emission standard."
 
   - name: "Fifth Generation (C8)"
-    start_year: 2019
+    start_year: 2018
     end_year: null
-    description: "The current C8 S6 represents a significant departure from tradition in some markets, featuring a twin-turbocharged 2.9L V6 petrol engine in some regions and a 3.0L V6 TDI diesel with electric compressor in others. Power outputs range from 344 HP to 450 HP depending on the market and engine. The exterior features more distinctive S-specific styling elements than previous generations, while the interior offers Audi's latest technology including dual touchscreens and digital instrumentation. Throughout its evolution, the S6 has balanced impressive performance with everyday usability and understated luxury."
+    description: "The current C8 S6 represents a significant departure, with different powertrains by market. The 2.9L twin-turbocharged V6 petrol TFSI produces 331 PS (450 HP) with a 48V mild-hybrid system for global markets, while European models feature a 3.0L turbocharged diesel V6 producing 253 PS (250 HP) with an electric compressor. Both configurations are paired with an 8-speed automatic Tiptronic transmission. The exterior features more distinctive S-specific styling elements than previous generations, while the interior offers Audi's latest technology including dual touchscreens and digital instrumentation. The C8 is built on the MLB Evo platform and went on sale in summer 2019 for European models."


### PR DESCRIPTION
- Added C6 Facelift (2009-2011) as separate entry per Wikipedia's late 2008 release for 2009 model year
- Added C7 Facelift (2015-2018) per Wikipedia's November 2014 announcement with styling and powertrain updates
- Corrected C6 start year from 2006 to 2005 per Wikipedia infobox production data
- Corrected C8 start year from 2019 to 2018 per Wikipedia infobox (summer 2019 for European, global 2018)
- Updated C7 end year from 2018 to 2014 (pre-facelift period) and added C7 Facelift with 450 HP upgrade
- Added complete references array with Wikipedia source

Evidence from Wikipedia:
- Infobox shows: C6 "production = 2005–2011", C7 "production = 2012–2018", C8 "production = 2018–present"
- Narrative: "A facelifted version of the S6 was released in late 2008 for the 2009 model year"
- Narrative: "Audi unveiled the 2015 S6 facelift in November 2014" with styling and tech upgrades
- C7.5 section details facelift changes including Matrix LED headlights, enhanced MMI, and 450 HP upgrade
- C8 section: European models went on sale in summer 2019 but production began 2018

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
